### PR TITLE
Adding pip installable `setup.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,4 @@ Documentation generator for python projects.
 
 # Steps
 1. `pip install --upgrade git+git://github.com/wandb/client.git@3a0def97afe1def2b1a59786b4f0bbcac3f5dc4c`
-2. Clone the repo
-3. `cd docugen`
-4. `pip install -e .`
+2. `pip install --upgrade git+git://github.com/arig23498/docugen@<branch-name>`

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,20 @@
 """Documentation Generator for wandb."""
-from setuptools import setup
+from setuptools import setup find_packages
 
-PROJECT_NAME = 'docugen'
-VERSION = '0.0.0'
+project_name = 'docugen'
+version = '0.0.0'
 REQUIRED_PKGS = [
     'astor',
 ]
 
 setup(
-    name=PROJECT_NAME,
-    version=VERSION,
+    name=project_name,
+    version=version,
     description="A documentation generator.",
     author="Artira Roy Gosthipaty",
     author_email="aritra.born2fly@gmail.com",
+    url='http://github.com/ariG23498/docugen',
+    download_url='https://github.com/ariG23498/docugen/tags',
     install_requires=REQUIRED_PKGS,
-    packages=['docugen'],
+    packages=find_packages('.'),
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ project_name = 'docugen'
 version = '0.0.0'
 REQUIRED_PKGS = [
     'astor',
+    'absl-py',
     'protobuf>=3.14',
+    'pyyaml',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ REQUIRED_PKGS = [
 setup(
     name=project_name,
     version=version,
-    description="A documentation generator.",
-    author="Artira Roy Gosthipaty",
-    author_email="aritra.born2fly@gmail.com",
+    description='A documentation generator.',
+    author='Artira Roy Gosthipaty',
+    author_email='aritra.born2fly@gmail.com',
     url='http://github.com/ariG23498/docugen',
     download_url='https://github.com/ariG23498/docugen/tags',
     install_requires=REQUIRED_PKGS,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 """Documentation Generator for wandb."""
-from setuptools import setup find_packages
+from setuptools import setup, find_packages
 
 project_name = 'docugen'
 version = '0.0.0'

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ project_name = 'docugen'
 version = '0.0.0'
 REQUIRED_PKGS = [
     'astor',
+    'protobuf>=3.14',
 ]
 
 setup(


### PR DESCRIPTION
In this PR:
1. Added requirements to `setup.py`
2. Used `find_packages()` to find the packages that need to be installed.

With this PR we would be able to pip install this module.